### PR TITLE
Update goimports instruction to include prefix

### DIFF
--- a/goimports/README.md
+++ b/goimports/README.md
@@ -52,6 +52,7 @@ goimports(
     name = "goimports",
     display_diffs = True,
     write = True,
+    prefix = "<your project prefix>",
 )
 ```
 Invoke with


### PR DESCRIPTION
Thank you for writing this tool to integrate goimports with Bazel! It seems like `prefix` is required for the target to run so wanted to make sure the documentation reflects this reality.