### PR TITLE
Pass bash parameters to wrapped commands

### DIFF
--- a/buildozer/runner.bash.template
+++ b/buildozer/runner.bash.template
@@ -9,7 +9,7 @@ ERROR_ON_NO_CHANGES=@@ERROR_ON_NO_CHANGES@@
 buildozer_short_path=$(readlink "$BUILDOZER_SHORT_PATH")
 cd "$BUILD_WORKSPACE_DIRECTORY"
 set +e
-"$buildozer_short_path" "${ARGS[@]}"
+"$buildozer_short_path" "${ARGS[@]}" $@
 ret=$?
 if [[ "$ret" -eq 3 && "$ERROR_ON_NO_CHANGES" == "false" ]]; then
     exit 0

--- a/goimports/runner.bash.template
+++ b/goimports/runner.bash.template
@@ -15,4 +15,4 @@ GOPATH=$(pwd -P)
 goimports_short_path=$(readlink "$GOIMPORTS_SHORT_PATH")
 CURDIR="$GOPATH/src/$PREFIX_DIR_PATH/$PREFIX_BASE_NAME"
 cd "$CURDIR"
-/usr/bin/env -i GOPATH="$GOPATH" PATH="$PATH" PWD="$CURDIR" "$goimports_short_path" "${ARGS[@]}" $(find . -type f -name  '*.go' -not -path './bazel-*' @@EXCLUDE_PATHS@@ @@EXCLUDE_FILES@@)
+/usr/bin/env -i GOPATH="$GOPATH" PATH="$PATH" PWD="$CURDIR" "$goimports_short_path" "${ARGS[@]}" $(find . -type f -name  '*.go' -not -path './bazel-*' @@EXCLUDE_PATHS@@ @@EXCLUDE_FILES@@) $@

--- a/gometalinter/def.bzl
+++ b/gometalinter/def.bzl
@@ -7,6 +7,8 @@ def _gometalinter_impl(ctx):
         args.append("--config=" + ctx.file.config.short_path)
     else:
         args.append("--no-config")
+    if ctx.attr.fast:
+        args.append("--fast")
     args.extend(ctx.attr.paths)
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     sdk = ctx.attr._go_sdk[GoSDK]
@@ -54,6 +56,10 @@ _gometalinter = rule(
         "prefix": attr.string(
             mandatory = True,
             doc = "Go import path of this project i.e. where in GOPATH you would put it. E.g. github.com/atlassian/bazel-tools",
+        ),
+        "fast": attr.bool(
+            default = False,
+            doc = "if the --fast flag should be set",
         ),
         "_gometalinter": attr.label(
             default = "@com_github_atlassian_bazel_tools_gometalinter//:linter",

--- a/gometalinter/def.bzl
+++ b/gometalinter/def.bzl
@@ -7,8 +7,6 @@ def _gometalinter_impl(ctx):
         args.append("--config=" + ctx.file.config.short_path)
     else:
         args.append("--no-config")
-    if ctx.attr.fast:
-        args.append("--fast")
     args.extend(ctx.attr.paths)
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     sdk = ctx.attr._go_sdk[GoSDK]
@@ -56,10 +54,6 @@ _gometalinter = rule(
         "prefix": attr.string(
             mandatory = True,
             doc = "Go import path of this project i.e. where in GOPATH you would put it. E.g. github.com/atlassian/bazel-tools",
-        ),
-        "fast": attr.bool(
-            default = False,
-            doc = "if the --fast flag should be set",
         ),
         "_gometalinter": attr.label(
             default = "@com_github_atlassian_bazel_tools_gometalinter//:linter",

--- a/gometalinter/runner.bash.template
+++ b/gometalinter/runner.bash.template
@@ -19,4 +19,4 @@ NEW_PATH="$NEW_GOPATH/external/com_github_atlassian_bazel_tools_gometalinter:$NE
 gometalinter_short_path=$(readlink "$GOMETALINTER_SHORT_PATH")
 CURDIR="$NEW_GOPATH/src/$PREFIX_DIR_PATH/$PREFIX_BASE_NAME"
 cd "$CURDIR"
-/usr/bin/env -i GOPATH="$NEW_GOPATH" GOROOT="$NEW_GOROOT" PATH="$NEW_PATH" PWD="$CURDIR" "$gometalinter_short_path" "${ARGS[@]}"
+/usr/bin/env -i GOPATH="$NEW_GOPATH" GOROOT="$NEW_GOROOT" PATH="$NEW_PATH" PWD="$CURDIR" "$gometalinter_short_path" "${ARGS[@]}" $@


### PR DESCRIPTION
Simplest way to allow users to set additional parameters without parsing and comparing things for overrides. We should probably prefer multiple copies of the target definition over smart parameter overrides inside the bash wrapper.