### PR TITLE
Pass on bash arguments

### DIFF
--- a/multirun/def.bzl
+++ b/multirun/def.bzl
@@ -21,7 +21,7 @@ def _multirun_impl(ctx):
         default_runfiles = info.default_runfiles
         if default_runfiles != None:
             transitive_depsets.append(default_runfiles.files)
-        content.append("echo Running %s\n./%s\n" % (shell.quote(str(command.label)), shell.quote(exe.short_path)))
+        content.append("echo Running %s\n./%s $@\n" % (shell.quote(str(command.label)), shell.quote(exe.short_path)))
 
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     ctx.actions.write(


### PR DESCRIPTION
This way all scripts that run in `multirun` still have access to passed shell arguments.
This fixes a problem we had in our own workflow and we figured it might be helpful for others.