### PR TITLE
Remove cfg host.

### DIFF
--- a/multirun/def.bzl
+++ b/multirun/def.bzl
@@ -46,7 +46,6 @@ _multirun = rule(
             mandatory = True,
             allow_files = True,
             doc = "Targets to run in specified order",
-            cfg = "host",
         ),
     },
     executable = True,


### PR DESCRIPTION
Having `cfg="host"` caused some of our transitive dependencies to be rebuilt unnecessarily. Even though I am not entirely sure why reading here: https://docs.bazel.build/versions/master/skylark/rules.html#configurations, it states `Otherwise, executables that are used at runtime (e.g. as part of a test) should be built for the target configuration. In this case, specify cfg="target" in the attribute.`. 

That sounds to me quite clearly that if we want to set it then we should set it to `cfg="target"`. What do you think?