### PR TITLE
Add unquoted environment option and exec the binary.

### DIFF
--- a/multirun/README.md
+++ b/multirun/README.md
@@ -32,6 +32,9 @@ command(
     environment = {
         "ABC": "DEF",
     },
+    raw_environment = {
+        "PATH": "$(pwd)/path",
+    },
 )
 
 multirun(

--- a/multirun/def.bzl
+++ b/multirun/def.bzl
@@ -45,7 +45,7 @@ _multirun = rule(
             mandatory = True,
             allow_files = True,
             doc = "Targets to run in specified order",
-            cfg = "host",
+            cfg = "target",
         ),
     },
     executable = True,
@@ -72,11 +72,17 @@ def _command_impl(ctx):
         "%s=%s" % (k, shell.quote(v))
         for k, v in ctx.attr.environment.items()
     ]
+    str_unqouted_env = [
+        "%s=%s" % (k, v)
+        for k, v in ctx.attr.raw_environment.items()
+    ]
     str_args = [
         "%s=%s" % (k, shell.quote(v))
         for k, v in ctx.attr.arguments.items()
     ]
-    command_elements = str_env + \
+    command_elements = ["exec env"] + \
+                       str_env + \
+                       str_unqouted_env + \
                        ["./%s" % shell.quote(defaultInfo.files_to_run.executable.short_path)] + \
                        str_args + \
                        ["$@\n"]
@@ -106,12 +112,15 @@ _command = rule(
         "environment": attr.string_dict(
             doc = "Dictionary of environment variables",
         ),
+        "raw_environment": attr.string_dict(
+            doc = "Dictionary of unqouted environment variables",
+        ),
         "command": attr.label(
             mandatory = True,
             allow_files = True,
             executable = True,
             doc = "Target to run",
-            cfg = "host",
+            cfg = "target",
         ),
     },
     executable = True,


### PR DESCRIPTION
This is mixing additional features as well as the change discussed in #44 - and I just added a new comment there, but maybe it makes more sense to continue the discussion here about it.

Other than that I noticed that we needed access to `pwd` so I added a new `raw_environment` so we have the possibility of adding unquoted environment variables.

Further I also added an `exec` statement to the `command` rule, purely to not have the bash process lingering around if one is running a longer running command.

I am also happy to take the `cfg=target` out again to get the other changes merged quicker if need be.