### PR TITLE
multirun(), command(): export RUNFILES_* envvars

### DIFF
--- a/multirun/def.bzl
+++ b/multirun/def.bzl
@@ -2,8 +2,6 @@ load("@bazel_skylib//lib:shell.bzl", "shell")
 
 _CONTENT_PREFIX = """#!/usr/bin/env bash
 
-set -euo pipefail
-
 # --- begin runfiles.bash initialization ---
 # Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
 set -euo pipefail


### PR DESCRIPTION
When binary (or test) "A" data-depends on binary
"B", Bazel merges B's runfiles into A's and only
generates a runfiles manifest/directory for "A"
but not "B". To let "B" find its runfiles, "A"
must export the "RUNFILES_*" envvars first. This
is common for tests (A) that run binaries (B) with
data-dependencies.

The multirun() and command() rules fall prey to
this runfiles-merging. To run `*_binary` targets,
they must discover and export the runfiles
envvars.

Fixes the bug in https://github.com/bazelbuild/bazel/pull/7774