### PR TITLE
Change arguments to list to accommodate for arguments without values.

### DIFF
--- a/multirun/README.md
+++ b/multirun/README.md
@@ -26,9 +26,11 @@ load("@com_github_atlassian_bazel_tools//:multirun/def.bzl", "multirun", "comman
 command(
     name = "command1",
     command = "//some/label",
-    arguments = {
-        "-arg1": "value1",
-    },
+    arguments = [
+        "-arg1",
+        "value1",
+        "-arg2",
+    ],
     environment = {
         "ABC": "DEF",
     },

--- a/multirun/def.bzl
+++ b/multirun/def.bzl
@@ -103,8 +103,8 @@ def _command_impl(ctx):
         for k, v in ctx.attr.raw_environment.items()
     ]
     str_args = [
-        "%s=%s" % (k, shell.quote(v))
-        for k, v in ctx.attr.arguments.items()
+        "%s" % shell.quote(v)
+        for v in ctx.attr.arguments
     ]
     command_elements = ["exec env"] + \
                        str_env + \
@@ -130,8 +130,8 @@ def _command_impl(ctx):
 _command = rule(
     implementation = _command_impl,
     attrs = {
-        "arguments": attr.string_dict(
-            doc = "Dictionary of command line arguments",
+        "arguments": attr.string_list(
+            doc = "List of command line arguments",
         ),
         "environment": attr.string_dict(
             doc = "Dictionary of environment variables",


### PR DESCRIPTION
For gazelle to be able to be executed properly using `multirun` one needs to pass `-bazel_run` as the first argument without any value. That does not work with the current dict approach. So I changed it to a list, which also matches the bazel `args` attribute. 

The other option I could think off is allowing an empty string to indicate no value, but that also seems a bit magic to me.

I know this is a breaking change, let me know what you think.