### PR TITLE
multirun: option to run commands in parallel

### DIFF
--- a/multirun/test/BUILD.bazel
+++ b/multirun/test/BUILD.bazel
@@ -1,0 +1,91 @@
+load("@com_github_atlassian_bazel_tools//:multirun/def.bzl", "command", "multirun")
+
+sh_test(
+    name = "test_multirun_success",
+    srcs = ["test_compare_content.sh"],
+    args = [
+        "$(location :multirun_success)",
+        "0",
+        "$(location expected_success.txt)",
+    ],
+    data = [
+        "expected_success.txt",
+        ":multirun_success",
+    ],
+)
+
+sh_test(
+    name = "test_multirun_failure",
+    srcs = ["test_compare_content.sh"],
+    args = [
+        "$(location :multirun_failure)",
+        "5",
+        "$(location expected_failure.txt)",
+    ],
+    data = [
+        "expected_failure.txt",
+        ":multirun_failure",
+    ],
+)
+
+sh_binary(
+    name = "exit",
+    srcs = ["exit.sh"],
+)
+
+sh_binary(
+    name = "echo",
+    srcs = ["echo.sh"],
+)
+
+multirun(
+    name = "multirun_success",
+    commands = [
+        ":command_echo_1",
+        ":command_echo_2",
+    ],
+)
+
+command(
+    name = "command_echo_1",
+    arguments = [
+        "command_1 a",
+        "command_1 b",
+    ],
+    command = ":echo",
+)
+
+command(
+    name = "command_echo_2",
+    arguments = [
+        "command_2 a",
+        "command_2 b",
+        "command_2 c",
+    ],
+    command = ":echo",
+)
+
+command(
+    name = "command_echo_3",
+    arguments = [
+        "command_3 a",
+    ],
+    command = ":echo",
+)
+
+multirun(
+    name = "multirun_failure",
+    commands = [
+        ":command_echo_2",
+        ":command_exit",
+        ":command_echo_3",
+    ],
+)
+
+command(
+    name = "command_exit",
+    arguments = [
+        "5",
+    ],
+    command = ":exit",
+)

--- a/multirun/test/BUILD.bazel
+++ b/multirun/test/BUILD.bazel
@@ -28,6 +28,38 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "test_multirun_parallel_success",
+    srcs = ["test_compare_content.sh"],
+    args = [
+        # Sort the output for deterministic comparison; order doesn't matter as long as all the expected lines are
+        # there.
+        "'$(location :multirun_parallel_success) | sort'",
+        "0",
+        "$(location expected_parallel_success.txt)",
+    ],
+    data = [
+        "expected_parallel_success.txt",
+        ":multirun_parallel_success",
+    ],
+)
+
+sh_test(
+    name = "test_multirun_parallel_failure",
+    srcs = ["test_compare_content.sh"],
+    args = [
+        # Sort the output for deterministic comparison; order doesn't matter as long as all the expected lines are
+        # there.
+        "'$(location :multirun_parallel_failure) | sort'",
+        "5",
+        "$(location expected_parallel_failure.txt)",
+    ],
+    data = [
+        "expected_parallel_failure.txt",
+        ":multirun_parallel_failure",
+    ],
+)
+
 sh_binary(
     name = "exit",
     srcs = ["exit.sh"],
@@ -44,6 +76,15 @@ multirun(
         ":command_echo_1",
         ":command_echo_2",
     ],
+)
+
+multirun(
+    name = "multirun_parallel_success",
+    commands = [
+        ":command_echo_2",
+        ":command_echo_1",
+    ],
+    parallel = True,
 )
 
 command(
@@ -80,6 +121,16 @@ multirun(
         ":command_exit",
         ":command_echo_3",
     ],
+)
+
+multirun(
+    name = "multirun_parallel_failure",
+    commands = [
+        ":command_echo_2",
+        ":command_exit",
+        ":command_echo_3",
+    ],
+    parallel = True,
 )
 
 command(

--- a/multirun/test/echo.sh
+++ b/multirun/test/echo.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Helper script for generating output lines in a test command; prints its arguments, one per line.
+
+for a in "$@"; do echo "$a"; done

--- a/multirun/test/echo.sh
+++ b/multirun/test/echo.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-# Helper script for generating output lines in a test command; prints its arguments, one per line.
+# Helper script for generating output lines in a test command; prints its arguments, one per line.  Sleeps in between to
+# make parallel tests' output more likely to be interleaved.
 
-for a in "$@"; do echo "$a"; done
+for a in "$@"; do echo "$a"; sleep 0.1; done

--- a/multirun/test/exit.sh
+++ b/multirun/test/exit.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Helper script for non-zero exit codes; prints and exits with its argument.
+
+echo "exiting $1"
+exit "$1"

--- a/multirun/test/expected_failure.txt
+++ b/multirun/test/expected_failure.txt
@@ -1,0 +1,6 @@
+Running //multirun/test:command_echo_2
+command_2 a
+command_2 b
+command_2 c
+Running //multirun/test:command_exit
+exiting 5

--- a/multirun/test/expected_parallel_failure.txt
+++ b/multirun/test/expected_parallel_failure.txt
@@ -1,0 +1,5 @@
+[//multirun/test:command_echo_2] command_2 a
+[//multirun/test:command_echo_2] command_2 b
+[//multirun/test:command_echo_2] command_2 c
+[//multirun/test:command_echo_3] command_3 a
+[//multirun/test:command_exit] exiting 5

--- a/multirun/test/expected_parallel_success.txt
+++ b/multirun/test/expected_parallel_success.txt
@@ -1,0 +1,5 @@
+[//multirun/test:command_echo_1] command_1 a
+[//multirun/test:command_echo_1] command_1 b
+[//multirun/test:command_echo_2] command_2 a
+[//multirun/test:command_echo_2] command_2 b
+[//multirun/test:command_echo_2] command_2 c

--- a/multirun/test/expected_success.txt
+++ b/multirun/test/expected_success.txt
@@ -1,0 +1,7 @@
+Running //multirun/test:command_echo_1
+command_1 a
+command_1 b
+Running //multirun/test:command_echo_2
+command_2 a
+command_2 b
+command_2 c

--- a/multirun/test/test_compare_content.sh
+++ b/multirun/test/test_compare_content.sh
@@ -3,7 +3,11 @@
 # Test harness.  Runs the command `$1`, checking that it exits with code `$2` and its stdout output matches the content
 # of `$3`.  Exits 0 if all is matching, non-0 otherwise.
 
-ACTUAL_STDOUT=$($1)
+set -o pipefail
+
+# Use `eval` instead of just `$($1)` to allow the command to include
+# pipelines.
+ACTUAL_STDOUT=$(eval "$1")
 ACTUAL_CODE=$?
 EXPECTED_CODE=$2
 EXPECTED_STDOUT=$(cat "$3")

--- a/multirun/test/test_compare_content.sh
+++ b/multirun/test/test_compare_content.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Test harness.  Runs the command `$1`, checking that it exits with code `$2` and its stdout output matches the content
+# of `$3`.  Exits 0 if all is matching, non-0 otherwise.
+
+ACTUAL_STDOUT=$($1)
+ACTUAL_CODE=$?
+EXPECTED_CODE=$2
+EXPECTED_STDOUT=$(cat "$3")
+
+if [[ "$ACTUAL_STDOUT" == "$EXPECTED_STDOUT" ]] && [[ "$ACTUAL_CODE" -eq "$EXPECTED_CODE" ]]
+then
+    echo "match"
+    exit 0
+else
+    echo "mismatch"
+    echo "expected code $EXPECTED_CODE, stdout:"
+    echo "$EXPECTED_STDOUT"
+    echo
+    echo "actual code $ACTUAL_CODE, stdout:"
+    echo "$ACTUAL_STDOUT"
+    exit 1
+fi


### PR DESCRIPTION
Running commands sequentially is a good and safe default, but for some instances, running the commands in parallel is better: it reduces end-to-end runtime if the commands are long-running and independent.  It's implemented with bash built-ins only (`read`, `&`, `wait`, etc) to avoid adding more deps.  The output in parallel mode is changed slightly so each line can be traced back to its writer.

I've also added some tests of both the existing behavior and the new.