### PR TITLE
Add Masterminds/sprig go template library

### DIFF
--- a/gotemplate/BUILD.bazel
+++ b/gotemplate/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/atlassian/bazel-tools/gotemplate",
     visibility = ["//visibility:private"],
     deps = [
+        "@com_github_masterminds_sprig//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )

--- a/gotemplate/deps.bzl
+++ b/gotemplate/deps.bzl
@@ -15,6 +15,78 @@ def gotemplate_dependencies():
         importpath = "gopkg.in/yaml.v2",
     )
 
+    _maybe(
+        go_repository,
+        name = "com_github_masterminds_sprig",
+        importpath = "github.com/Masterminds/sprig",
+        sum = "h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=",
+        version = "v2.22.0+incompatible",
+    )
+
+    _maybe(
+        go_repository,
+        name = "com_github_masterminds_goutils",
+        importpath = "github.com/Masterminds/goutils",
+        sum = "h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=",
+        version = "v1.1.0",
+    )
+
+    _maybe(
+        go_repository,
+        name = "com_github_masterminds_semver",
+        importpath = "github.com/Masterminds/semver",
+        sum = "h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=",
+        version = "v1.5.0",
+    )
+
+    _maybe(
+        go_repository,
+        name = "org_golang_x_crypto",
+        importpath = "golang.org/x/crypto",
+        sum = "h1:3zb4D3T4G8jdExgVU/95+vQXfpEPiMdCaZgmGVxjNHM=",
+        version = "v0.0.0-20200323165209-0ec3e9974c59",
+    )
+
+    _maybe(
+        go_repository,
+        name = "com_github_imdario_mergo",
+        importpath = "github.com/imdario/mergo",
+        sum = "h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=",
+        version = "v0.3.9",
+    )
+
+    _maybe(
+        go_repository,
+        name = "com_github_google_uuid",
+        importpath = "github.com/google/uuid",
+        sum = "h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=",
+        version = "v1.1.1",
+    )
+
+    _maybe(
+        go_repository,
+        name = "com_github_huandu_xstrings",
+        importpath = "github.com/huandu/xstrings",
+        sum = "h1:gvV6jG9dTgFEncxo+AF7PH6MZXi/vZl25owA/8Dg8Wo=",
+        version = "v1.3.0",
+    )
+
+    _maybe(
+        go_repository,
+        name = "com_github_mitchellh_copystructure",
+        importpath = "github.com/mitchellh/copystructure",
+        sum = "h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=",
+        version = "v1.0.0",
+    )
+
+    _maybe(
+        go_repository,
+        name = "com_github_mitchellh_reflectwalk",
+        importpath = "github.com/mitchellh/reflectwalk",
+        sum = "h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=",
+        version = "v1.0.1",
+    )
+
 def _maybe(repo_rule, name, **kwargs):
     if name not in native.existing_rules():
         repo_rule(name = name, **kwargs)

--- a/gotemplate/main.go
+++ b/gotemplate/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig"
 	"gopkg.in/yaml.v2"
 )
 
@@ -78,7 +79,7 @@ func (a arguments) processTemplate(context map[string]interface{}) (finalError e
 	}
 	defer closeWithError(out)
 
-	tmpl, err := template.New("template").Delims(a.leftDelim, a.rightDelim).Parse(string(data))
+	tmpl, err := template.New("template").Funcs(sprig.TxtFuncMap()).Delims(a.leftDelim, a.rightDelim).Parse(string(data))
 	if err != nil {
 		return fmt.Errorf("failed to parse template: %v", err)
 	}


### PR DESCRIPTION
Hi,

this PR adds https://github.com/Masterminds/sprig Go template functions library thats also used in Helm project extensively.

This library adds [tons of very useful functions](http://masterminds.github.io/sprig/) that make writing go templates a bit more interesting.

When creating the PR, I noticed it pulls in tons of dependencies. So I'd understand if this is too much for you :)

BTW I've already signed the CLA