### PR TITLE
goimports requires GOCACHE set under certain circumstances

### DIFF
--- a/goimports/runner.bash.template
+++ b/goimports/runner.bash.template
@@ -11,8 +11,10 @@ mkdir -p "src/$PREFIX_DIR_PATH"
 ln -snf "$BUILD_WORKSPACE_DIRECTORY" "src/$PREFIX_DIR_PATH/$PREFIX_BASE_NAME"
 
 GOPATH=$(pwd -P)
+GOCACHE="$(mktemp -d)"
+trap "rm -rf '${GOCACHE}'" EXIT
 
 goimports_short_path=$(readlink "$GOIMPORTS_SHORT_PATH")
 CURDIR="$GOPATH/src/$PREFIX_DIR_PATH/$PREFIX_BASE_NAME"
 cd "$CURDIR"
-/usr/bin/env -i GOPATH="$GOPATH" PATH="$PATH" PWD="$CURDIR" "$goimports_short_path" "${ARGS[@]}" $(find . -type f -name  '*.go' -not -path './bazel-*' @@EXCLUDE_PATHS@@ @@EXCLUDE_FILES@@) "$@"
+/usr/bin/env -i GOPATH="$GOPATH" GOCACHE="${GOCACHE}" PATH="$PATH" PWD="$CURDIR" "$goimports_short_path" "${ARGS[@]}" $(find . -type f -name  '*.go' -not -path './bazel-*' @@EXCLUDE_PATHS@@ @@EXCLUDE_FILES@@) "$@"

--- a/golangcilint/runner.bash.template
+++ b/golangcilint/runner.bash.template
@@ -17,6 +17,8 @@ DIRECTORY="$(pwd -P)"
 NEW_GOPATH="${DIRECTORY}"
 NEW_GOROOT="${DIRECTORY}/${NEW_GOROOT}"
 NEW_PATH="${NEW_GOPATH}/external/com_github_atlassian_bazel_tools_golangcilint:${NEW_GOROOT}/bin:${PATH}"
+GOCACHE="$(mktemp -d)"
+trap "rm -rf '${GOCACHE}'" EXIT
 
 golangcilint_short_path=$(readlink "${GOLANGCILINT_SHORT_PATH}")
 CURDIR="${NEW_GOPATH}/src/${PREFIX_DIR_PATH}/${PREFIX_BASE_NAME}"
@@ -26,7 +28,7 @@ cd "${CURDIR}"
     -i \
     GOPATH="${NEW_GOPATH}"\
     GOROOT="${NEW_GOROOT}"\
-    GOCACHE="$(mktemp -d)"\
+    GOCACHE="${GOCACHE}"\
     GOLANGCI_LINT_CACHE="$(mktemp -d)"\
     PATH="${NEW_PATH}"\
     PWD="${CURDIR}"\


### PR DESCRIPTION
If imports can't be resolved and no GOCACHE variable is set, goimports fails with:

```
build cache is required, but could not be located: GOCACHE is not
defined and neither $XDG_CACHE_HOME nor $HOME are defined
```

Setting GOCACHE to a temporary directory is good enough to fix that.

This seems to be a change in the goimports code: https://github.com/golang/go/issues/32238