### PR TITLE
Add 'quiet' to multirun

### DIFF
--- a/multirun/def.bzl
+++ b/multirun/def.bzl
@@ -63,6 +63,7 @@ def _multirun_impl(ctx):
     instructions = struct(
         commands = commands,
         parallel = ctx.attr.parallel,
+        quiet = ctx.attr.quiet,
     )
     ctx.actions.write(
         output = instructions_file,
@@ -106,6 +107,10 @@ _multirun = rule(
         "parallel": attr.bool(
             default = False,
             doc = "If true, targets will be run in parallel, not in the specified order",
+        ),
+        "quiet": attr.bool(
+            default = False,
+            doc = "Limit output where possible",
         ),
         "_bash_runfiles": attr.label(
             default = Label("@bazel_tools//tools/bash/runfiles"),

--- a/multirun/main.go
+++ b/multirun/main.go
@@ -46,6 +46,7 @@ type command struct {
 type instructions struct {
 	Commands []command `json:"commands"`
 	Parallel bool      `json:"parallel"`
+	Quiet    bool      `json:"quiet"`
 }
 
 type arguments struct {
@@ -76,6 +77,7 @@ func (a arguments) run(ctx context.Context) (int, error) {
 		stderrSink: os.Stderr,
 		args:       a.args,
 		parallel:   instr.Parallel,
+		quiet:      instr.Quiet,
 	}
 	err = m.run(ctx)
 	if err != nil {

--- a/multirun/multirun.go
+++ b/multirun/multirun.go
@@ -11,6 +11,7 @@ type multirun struct {
 	stdoutSink, stderrSink io.Writer
 	args                   []string
 	parallel               bool
+	quiet                  bool
 }
 
 func (m multirun) run(ctx context.Context) error {
@@ -45,7 +46,9 @@ func (m multirun) run(ctx context.Context) error {
 				stderrSink: m.stderrSink,
 				args:       m.args,
 			}
-			fmt.Fprintf(m.stderrSink, "Running %s\n", cmd.Tag)
+			if !m.quiet {
+				fmt.Fprintf(m.stderrSink, "Running %s\n", cmd.Tag)
+			}
 			if err := p.run(ctx); err != nil {
 				return err
 			}


### PR DESCRIPTION
This adds a new attribute to multirun that allows users to decrease the
output they see. Right now this only affects the "Running [LABEL]"
output but I kept the name intentionally generic so it can also be used
for other things in the future where it makes sense.

Fixes https://github.com/atlassian/bazel-tools/issues/130